### PR TITLE
Tests: Restore 100% coverage for FoodLogService

### DIFF
--- a/src/test/java/Test/FoodLogServiceTest.java
+++ b/src/test/java/Test/FoodLogServiceTest.java
@@ -308,4 +308,17 @@ public class FoodLogServiceTest {
         assertEquals(tomorrow, saved.getDate());
         assertEquals(1, saved.getMeals().size());
     }
+
+    /**
+     * Test the new MyFoodRepository getter added by teammates.
+     */
+    @Test
+    public void testGetMyFoodRepository() {
+        // Arrange
+        InMemoryMyFoodRepository myFoodRepo = new InMemoryMyFoodRepository();
+        FoodLogService service = new FoodLogService(null, null, new MockSettingsRepo(), myFoodRepo);
+
+        // Act & Assert
+        assertNotNull(service.getMyFoodRepository(), "Should return the injected MyFoodRepository");
+    }
 }


### PR DESCRIPTION
Recent changes to `main` introduced new getter methods in `FoodLogService`. This caused the test coverage to drop below 100%. This PR adds the necessary test case (`testGetMyFoodRepository`) to bring the line coverage back to **100%**.

Evidence:
<img width="792" height="89" alt="截屏2025-11-30 18 29 14" src="https://github.com/user-attachments/assets/002a77ce-f8ad-403f-b39b-ddc6e93515e1" />
